### PR TITLE
fix(docs): add '.git' for clone repo to fix guide/index.md

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -46,7 +46,7 @@
 
 ```bash
 # clone 代码
-git clone https://github.com/vbenjs/vue-vben-admin
+git clone https://github.com/vbenjs/vue-vben-admin.git
 
 ```
 
@@ -57,7 +57,7 @@ git clone https://github.com/vbenjs/vue-vben-admin
 也可以通过下方地址进行 clone
 
 ```bash
-git clone https://gitee.com/annsion/vue-vben-admin
+git clone https://gitee.com/annsion/vue-vben-admin.git
 ```
 
 ::: warning 注意


### PR DESCRIPTION
@anncwb
以下 clone 源码的地址是错的，缺少了`.git`后缀，本次PR修复了该问题。

文档地址：[https://vvbin.cn/doc-next/guide/#%E4%BB%A3%E7%A0%81%E8%8E%B7%E5%8F%96](https://vvbin.cn/doc-next/guide/#%E4%BB%A3%E7%A0%81%E8%8E%B7%E5%8F%96)

![image](https://user-images.githubusercontent.com/9566362/162604624-ade05974-61d2-46cc-a718-ce0af9e20bda.png)

