### PR TITLE
docs: 更新淘宝镜像源地址

### DIFF
--- a/other/faq.md
+++ b/other/faq.md
@@ -127,7 +127,7 @@ getCurrentInstance().ctx.xxxx;
 
 ```bash
 # .npmrc
-registry = https://registry.npm.taobao.org
+registry = https://registry.npmmirror.com/
 ```
 
 然后重新执行`yarn run reinstall`等待安装完成即可


### PR DESCRIPTION
淘宝镜像源 原地址证书已过期, 更新为新的淘宝镜像源